### PR TITLE
removing the individual cell index when referring to the gene's log expression variance

### DIFF
--- a/theory/description.tex
+++ b/theory/description.tex
@@ -153,7 +153,7 @@ By first using a parametric curve to model the complex parts of the trend, we ca
 
 \subsection{Decomposing the variance components}
 Consider an endogenous gene $g$, which has a true log-expression of $y_{ig}^*$ in cell $i$.
-Let $\mbox{var}(y_{ig}^*) = \sigma^2_{(b)g}$, representing the underlying biological variation.
+Let $\mbox{var}(y_{g}^*) = \sigma^2_{(b)g}$, representing the underlying biological variation of $g$ across all cells.
 The observed log-expression $y_{ig}$ is then sampled from $y_{ig}|y_{ig}^* \sim T_{ig}$ with $E(T_{ig}) = y^*_{ig}$, representing the effect of technical noise.
 The observed variance is 
 \begin{align*}


### PR DESCRIPTION
I think the variance of log expression of a gene for a cell would be zero and hence we are talking about the variance across the population? If so, I think a further correction is needed, possibly.